### PR TITLE
update Dockerfile to use Postgres 9.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV REFRESHED_AT 2015-11-10
 RUN apt-get update -y && apt-get install -y wget ca-certificates lsb-release git python python-pip python-dev nginx supervisor python-setuptools sudo
 RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN apt-get update -y && apt-get upgrade -y && apt-get install -y postgresql-9.5 postgresql-plpython-9.5 postgresql-server-dev-9.5 pgxnclient fuse libfuse-dev sendmail
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y postgresql-9.6 postgresql-plpython-9.6 postgresql-server-dev-9.6 pgxnclient fuse libfuse-dev sendmail
 RUN pgxn install multicorn
 RUN pgxn install pgtap
 RUN pip install requests sphinx sphinx-autobuild fusepy
@@ -59,9 +59,9 @@ RUN mkdir /mnt/aquameta
 #################### build aquameta ###############################
 USER postgres
 WORKDIR /s/aquameta
-RUN echo "host all  all 0.0.0.0/0  md5"   >> /etc/postgresql/9.5/main/pg_hba.conf && \
-	sed -i "s/^local   all.*$/local all all trust/" /etc/postgresql/9.5/main/pg_hba.conf && \
-	echo "listen_addresses='*'" >> /etc/postgresql/9.5/main/postgresql.conf && \
+RUN echo "host all  all 0.0.0.0/0  md5"   >> /etc/postgresql/9.6/main/pg_hba.conf && \
+	sed -i "s/^local   all.*$/local all all trust/" /etc/postgresql/9.6/main/pg_hba.conf && \
+	echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf && \
 	/etc/init.d/postgresql start && \
 	./build.sh && \
 	psql -c "alter role postgres password 'postgres'" aquameta

--- a/core/000-meta/semantics.sql
+++ b/core/000-meta/semantics.sql
@@ -10,19 +10,19 @@ begin;
 
 set search_path=semantics;
 
-insert into semantics.relation (id, list_item_identifier_widget_id) values
+insert into semantics.relation (relation_id, widget_id) values
 (
     ( select relation_id from meta.relation_id('meta', 'schema') ),
     ( select id from widget.widget where name = 'meta_schema_listitem_identifier')
 );
 
-insert into semantics.relation (id, list_item_identifier_widget_id) values
+insert into semantics.relation (relation_id, widget_id) values
 (
     ( select relation_id from meta.relation_id('meta', 'relation') ),
     ( select id from widget.widget where name = 'relation_listitem_identifier')
 );
 
-insert into semantics.relation (id, list_item_identifier_widget_id) values
+insert into semantics.relation (relation_id, widget_id) values
 (
     ( select relation_id from meta.relation_id('meta', 'column') ),
     ( select id from widget.widget where name = 'column_listitem_identifier')

--- a/core/004-aquameta_endpoint/semantics.sql
+++ b/core/004-aquameta_endpoint/semantics.sql
@@ -10,13 +10,13 @@ begin;
 
 set search_path = semantics;
 
-insert into semantics.relation (id, list_item_identifier_widget_id) values
+insert into semantics.relation (relation_id, widget_id) values
 (
     ( select relation_id from meta.relation_id('www', 'resource') ),
     ( select id from widget.widget where name = 'www_resource_listitem_identifier')
 );
 
-insert into semantics.relation (id, list_item_identifier_widget_id) values
+insert into semantics.relation (relation_id, widget_id) values
 (
     ( select relation_id from meta.relation_id('www', 'mimetype') ),
     ( select id from widget.widget where name = 'www_mimetype_listitem_identifier')

--- a/core/007-widget/semantics.sql
+++ b/core/007-widget/semantics.sql
@@ -10,7 +10,7 @@ begin;
 
 set search_path=semantics;
 
-insert into semantics.relation (id, list_item_identifier_widget_id) values
+insert into semantics.relation (relation_id, widget_id) values
 (
     ( select relation_id from meta.relation_id('widget', 'widget') ),
     ( select id from widget.widget where name = 'widget_widget_listitem_identifier')

--- a/core/008-semantics/semantics.sql
+++ b/core/008-semantics/semantics.sql
@@ -9,27 +9,16 @@ begin;
 
 set search_path=semantics;
 
-/*
-
-doesn't work:
-
-ERROR:  column "list_item_identifier_widget_id" of relation "relation" does not exist
-LINE 1: insert into semantics.relation (id, list_item_identifier_wid...
-
-
-
-
-insert into semantics.relation (id, list_item_identifier_widget_id) values
+insert into semantics.relation (relation_id, widget_id) values
 (
     ( select relation_id from meta.relation_id('semantics', 'relation') ),
     ( select id from widget.widget where name = 'relation_listitem_identifier')
 );
 
-insert into semantics.relation (id, list_item_identifier_widget_id) values
+insert into semantics.relation (relation_id, widget_id) values
 (
     ( select relation_id from meta.relation_id('semantics', 'column') ),
     ( select id from widget.widget where name = 'column_listitem_identifier')
 );
 
-*/ 
 commit;

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -4,7 +4,7 @@ nodaemon = true
 
 [program:postgres]
 user = postgres
-command = /usr/lib/postgresql/9.5/bin/postgres -D /var/lib/postgresql/9.5/main -c config_file=/etc/postgresql/9.5/main/postgresql.conf
+command = /usr/lib/postgresql/9.6/bin/postgres -D /var/lib/postgresql/9.6/main -c config_file=/etc/postgresql/9.6/main/postgresql.conf
 stdout_events_enabled=true
 stderr_events_enabled=true
 


### PR DESCRIPTION
Fixes:
* updates Dockerfile and supervisor config to use PostgreSQL 9.6 as required by some views using new columns
* fix column names in `semantics.sql` to make `build.sh` run successfully