### PR TITLE
Fix event subscriptions

### DIFF
--- a/extensions/event/000-event.sql
+++ b/extensions/event/000-event.sql
@@ -505,11 +505,11 @@ create or replace function event.subscribe_table(
                   trigger_name,
                   (relation_id.schema_id).name,
                   relation_id.name);
-
-          insert into event.subscription_table(session_id, relation_id)
-              values(session_id, relation_id)
-              on conflict do nothing;
         end if;
+
+        insert into event.subscription_table(session_id, relation_id)
+            values(session_id, relation_id)
+            on conflict do nothing;
 
     end;
 $$ language plpgsql security definer;
@@ -553,11 +553,11 @@ create or replace function event.subscribe_column(
                   trigger_name,
                   (relation_id.schema_id).name,
                   relation_id.name);
-
-          insert into event.subscription_column(session_id, column_id)
-              values(session_id, column_id)
-              on conflict do nothing;
         end if;
+
+        insert into event.subscription_column(session_id, column_id)
+            values(session_id, column_id)
+            on conflict do nothing;
 
     end;
 $$ language plpgsql security definer;
@@ -601,11 +601,11 @@ create or replace function event.subscribe_row(
                   trigger_name,
                   (relation_id.schema_id).name,
                   relation_id.name);
-
-          insert into event.subscription_row(session_id, row_id)
-              values(session_id, row_id)
-              on conflict do nothing;
         end if;
+
+        insert into event.subscription_row(session_id, row_id)
+            values(session_id, row_id)
+            on conflict do nothing;
 
     end;
 $$ language plpgsql security definer;
@@ -649,11 +649,11 @@ create or replace function event.subscribe_field(
                   trigger_name,
                   (relation_id.schema_id).name,
                   relation_id.name);
-
-          insert into event.subscription_field(session_id, field_id)
-              values(session_id, field_id)
-              on conflict do nothing;
         end if;
+
+        insert into event.subscription_field(session_id, field_id)
+            values(session_id, field_id)
+            on conflict do nothing;
 
     end;
 $$ language plpgsql security definer;

--- a/extensions/event/event--0.3.0.sql
+++ b/extensions/event/event--0.3.0.sql
@@ -505,11 +505,11 @@ create or replace function event.subscribe_table(
                   trigger_name,
                   (relation_id.schema_id).name,
                   relation_id.name);
-
-          insert into event.subscription_table(session_id, relation_id)
-              values(session_id, relation_id)
-              on conflict do nothing;
         end if;
+
+        insert into event.subscription_table(session_id, relation_id)
+            values(session_id, relation_id)
+            on conflict do nothing;
 
     end;
 $$ language plpgsql security definer;
@@ -553,11 +553,11 @@ create or replace function event.subscribe_column(
                   trigger_name,
                   (relation_id.schema_id).name,
                   relation_id.name);
-
-          insert into event.subscription_column(session_id, column_id)
-              values(session_id, column_id)
-              on conflict do nothing;
         end if;
+
+        insert into event.subscription_column(session_id, column_id)
+            values(session_id, column_id)
+            on conflict do nothing;
 
     end;
 $$ language plpgsql security definer;
@@ -601,11 +601,11 @@ create or replace function event.subscribe_row(
                   trigger_name,
                   (relation_id.schema_id).name,
                   relation_id.name);
-
-          insert into event.subscription_row(session_id, row_id)
-              values(session_id, row_id)
-              on conflict do nothing;
         end if;
+
+        insert into event.subscription_row(session_id, row_id)
+            values(session_id, row_id)
+            on conflict do nothing;
 
     end;
 $$ language plpgsql security definer;
@@ -649,11 +649,11 @@ create or replace function event.subscribe_field(
                   trigger_name,
                   (relation_id.schema_id).name,
                   relation_id.name);
-
-          insert into event.subscription_field(session_id, field_id)
-              values(session_id, field_id)
-              on conflict do nothing;
         end if;
+
+        insert into event.subscription_field(session_id, field_id)
+            values(session_id, field_id)
+            on conflict do nothing;
 
     end;
 $$ language plpgsql security definer;

--- a/main.go
+++ b/main.go
@@ -777,7 +777,7 @@ log.Print(`                 [ version 0.3.0 ]                     `)
             // start wait process
             go start(cn.Conn())
 
-            r, err := pool.Query(context.Background(), "delete from event.session where id=$1;", sessionId)
+            r, err := pool.Query(context.Background(), "delete from event.session where id=$1 cascade;", sessionId)
             if err != nil {
               fmt.Println("wsServer error deleting old session:", err)
             }


### PR DESCRIPTION
Insert subscription whether pg_trigger exists or not

Also I added 'cascade' to the websocket detach logic so we delete events from detached sessions.