### PR TITLE
Add gitignores to clean up local checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 .idea
 aquameta
 bootloader.db/
-extensions/*/*--0.3.0.sql
+extensions/*/*--*.sql
+conf/boot.toml
 conf/*.local.toml

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 aquameta
 bootloader.db/
 extensions/*/*--0.3.0.sql
+conf/*.local.toml

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ sudo ./make_install_extensions.sh
 cd ../
 ```
 
+*Note for Mac users: this may fail with a cryptic permissions error if
+your terminal program does not have Full Disk Access. This can be set
+via System Preferences.*
+
 4. Install [Golang](https://golang.org/) version 1.18 or greater, then build
 the `./aquameta` binary from aquameta's root directory:
 


### PR DESCRIPTION
`conf/boot.toml` is the suggested starting point in the install directions, so we should ignore it. For developers, its probably wise to allow a pattern like `*.local.toml` so you can have several configurations to test.