### PR TITLE
Require resource_functions to return a record

### DIFF
--- a/extensions/endpoint/001-server.sql
+++ b/extensions/endpoint/001-server.sql
@@ -113,6 +113,13 @@ create table endpoint.resource_directory (
     indexes boolean
 );
 
+-- TODO: Reasonable default value for content
+--  This would need to be dependent on mimetype. Maybe template table?
+--  For HTML files, would need an update function to pass in bundle name
+--  Could have endpoint.create_resource_from_template(type, args);
+--  Get mimetype from template, and does find/replace with args in
+--  template content string. Could use args column of endpoint.template
+--  to create a form that you need to submit for each template creation.
 create table endpoint.resource (
     id uuid not null default public.uuid_generate_v4() primary key,
     path text not null,
@@ -139,7 +146,7 @@ create table endpoint.resource (
 create table endpoint.resource_function (
     id uuid not null default public.uuid_generate_v4() primary key,
     function_id meta.function_id not null,
-    path_pattern text not null, -- /blogs/{$1}/posts/{$2}.html -- the numbers correspond to the position of the argument passed to the specified function
+    path_pattern text not null, -- /blogs/${1}/posts/${2}.html -- the numbers correspond to the position of the argument passed to the specified function
     default_args text[] not null default '{}', -- for setting fixed arguments to the function, when only some of the args are specified by the path. array position corresponds to function args position.
     mimetype_id uuid references mimetype(id) -- if this function always returns the same mimetype, set this
 );

--- a/extensions/endpoint/001-server.sql
+++ b/extensions/endpoint/001-server.sql
@@ -1704,6 +1704,19 @@ language plpgsql;
  * FUNCTION request
  ****************************************************************************************************/
 
+/**
+ * TODO: Ensure backwards compatibility with endpoint
+ * Endpoint is the entrypoint for all access to data
+ * Therefore, endpoint should always support backwards compatibility
+ * Every new version of the bundle should maintain old endpoints
+ * /endpoint/0.3/ and /endpoint/0.1/ should both try to find the endpoint bundle version they specify
+ *  *but* they should be able to fallback to querying the most recent version of endpoint if it is
+ *  greater than the requested version. it would take the version number and add it to the metadata
+ * so /endpoint/0.1/ to a database that only has 0.3 should turn into
+ * /endpoint/0.3/?endpoint_version=0.1
+ * and endpoint will call the old functions since 0.3 will contain 0.2 and 0.1
+ */
+
 create or replace function endpoint.request(
     version text,
     verb text,

--- a/resource.go
+++ b/resource.go
@@ -63,7 +63,7 @@ func resource(dbpool *pgxpool.Pool) func(w http.ResponseWriter, req *http.Reques
             -- 1. rewrite path_pattern to a regex:
             --     /blog/{$1}/article/{$2} goes to ^/blog/(\S+)/article/(\S+)$
             -- 2. matche against the request path
-            where %v ~ regexp_replace('^' || r.path_pattern || '$', '{\$\d+}', '(\S+)', 'g')`
+            where %v ~ regexp_replace('^' || r.path_pattern || '$', '\${\d+}', '(\S+)', 'g')`
 
         /*
            union
@@ -158,8 +158,8 @@ func resource(dbpool *pgxpool.Pool) func(w http.ResponseWriter, req *http.Reques
                     (rf.function_id).parameters as function_parameters,
                     rf.default_args as default_args,
                     m.mimetype,
-                    regexp_match(%v, regexp_replace('^' || rf.path_pattern || '$', '{\$\d+}', '(\S+)', 'g')) as args,
-                    (select array_agg(m[1]::integer) from regexp_matches(rf.path_pattern, '{\$(\d+)}', 'g') m) 
+                    regexp_match(%v, regexp_replace('^' || rf.path_pattern || '$', '\${\d+}', '(\S+)', 'g')) as args,
+                    (select array_agg(m[1]::integer) from regexp_matches(rf.path_pattern, '\${(\d+)}', 'g') m) 
                 from endpoint.resource_function rf
                     join endpoint.mimetype m on rf.mimetype_id = m.id
                 where rf.id = %v`

--- a/resource.go
+++ b/resource.go
@@ -61,7 +61,7 @@ func resource(dbpool *pgxpool.Pool) func(w http.ResponseWriter, req *http.Reques
             select r.id::text, 'resource_function'
             from endpoint.resource_function r
             -- 1. rewrite path_pattern to a regex:
-            --     /blog/{$1}/article/{$2} goes to ^/blog/(\S+)/article/(\S+)$
+            --     /blog/${1}/article/${2} goes to ^/blog/(\S+)/article/(\S+)$
             -- 2. matche against the request path
             where %v ~ regexp_replace('^' || r.path_pattern || '$', '\${\d+}', '(\S+)', 'g')`
 


### PR DESCRIPTION
Require resource_functions to return a record containing custom headers (#262)

This also swaps the string replace format for a more familiar one (though we have that discussion in the linked issue - #264)

Fixes #262 and #264 