### PR TITLE
Prevent resource function regex from matching back slash

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -61,9 +61,9 @@ func resource(dbpool *pgxpool.Pool) func(w http.ResponseWriter, req *http.Reques
             select r.id::text, 'resource_function'
             from endpoint.resource_function r
             -- 1. rewrite path_pattern to a regex:
-            --     /blog/{$1}/article/{$2} goes to ^/blog/(\S+)/article/(\S+)$
-            -- 2. matche against the request path
-            where %v ~ regexp_replace('^' || r.path_pattern || '$', '\${\d+}', '(\S+)', 'g')`
+            --     /blog/{$1}/article/{$2} goes to ^/blog/([^\/\s]+)/article/([^\/\s]+)$
+            -- 2. match against the request path
+            where %v ~ regexp_replace('^' || r.path_pattern || '$', '\${\d+}', '([^\/\s]+)', 'g')`
 
         /*
            union
@@ -158,7 +158,7 @@ func resource(dbpool *pgxpool.Pool) func(w http.ResponseWriter, req *http.Reques
                     (rf.function_id).parameters as function_parameters,
                     rf.default_args as default_args,
                     m.mimetype,
-                    regexp_match(%v, regexp_replace('^' || rf.path_pattern || '$', '\${\d+}', '(\S+)', 'g')) as args,
+                    regexp_match(%v, regexp_replace('^' || rf.path_pattern || '$', '\${\d+}', '([^\/\s]+)', 'g')) as args,
                     (select array_agg(m[1]::integer) from regexp_matches(rf.path_pattern, '\${(\d+)}', 'g') m),
                     mf.return_type = 'record' as returns_record
                 from endpoint.resource_function rf


### PR DESCRIPTION
Fix resource function regex to disallow matching back slash. This fixes a bug where resource_function will match the wrong pattern because `\S` matches `/`