### PR TITLE
pgfs: cross-platform support (or not)

### DIFF
--- a/conf/boot.toml.dist
+++ b/conf/boot.toml.dist
@@ -49,4 +49,5 @@
 
 
 [PGFS]
+    Enabled = false
     MountDirectory = "pgfs/"

--- a/conf/bootloader.toml
+++ b/conf/bootloader.toml
@@ -47,4 +47,5 @@
 
 
 [PGFS]
+    Enabled = false
     MountDirectory = "pgfs/"

--- a/config.go
+++ b/config.go
@@ -38,6 +38,7 @@ type HTTPServer struct {
 
 
 type PGFS struct {
+    Enabled bool
     MountDirectory string
 }
 

--- a/main.go
+++ b/main.go
@@ -15,8 +15,6 @@ import (
     "path/filepath"
     "syscall"
     "time"
-    "bazil.org/fuse"
-    "bazil.org/fuse/fs"
 )
 
 func main() {
@@ -384,38 +382,12 @@ func main() {
     }()
 
 
-    log.Printf("Mounting PGFS Filesystem: %s\n\n", config.PGFS.MountDirectory)
+    //
+    // start pgfs (if OS is supported and it's enabled in config)
+    //
 
-    go func() {
-        c, err := fuse.Mount(
-            config.PGFS.MountDirectory,
-            fuse.FSName("pgfsfs"),
-            fuse.Subtype("pgfs"),
-        )
-        if err != nil {
-            log.Fatal(err)
-        }
-        defer c.Close()
+    go pgfs(config, dbpool, fuseDone)
 
-        err = fs.Serve(c, FS{dbpool: dbpool})
-        if err != nil {
-            log.Fatal(err)
-        }
-/*
-        server, _, err := fuse.Mount(
-            "/tmp/mnt",
-            fs,
-            &fuse.MountOptions{
-                AllowOther: true,
-            },
-        )
-        if err != nil {
-            println("FUSE filesystem error:", err)
-        }
-        server.Wait()
-*/
-        fuseDone <- true
-    }()
 
     //
     // start gui

--- a/pgfs_unsupported.go
+++ b/pgfs_unsupported.go
@@ -1,0 +1,10 @@
+//go:build !(linux || freebsd)
+package main
+
+import "github.com/jackc/pgx/v4/pgxpool"
+
+func pgfs(config tomlConfig, dbpool *pgxpool.Pool, fuseDone chan bool) {
+	if tomlConfig.PGFS.Enabled {
+        log.Printf("PGFS Filesystem uses the bazil.org/fuse library which supports Linux and FreeBSD only.\n\n")
+    }
+}


### PR DESCRIPTION
- use build constraints to only build pgfs on supported platforms
- use pgfs_unsupported.go on unsupported platforms (mac etc)
- add PGFS.Enabled variable, defaulting to false in dist configs