### PR TITLE
Fix schema_id reference in server resource_function invocation

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -153,7 +153,7 @@ func resource(dbpool *pgxpool.Pool) func(w http.ResponseWriter, req *http.Reques
             const resourceFunctionPrepQ = `
                 select
                     rf.path_pattern,
-                    ((rf.function_id).schema_id).name as schema_name,
+                    (rf.function_id).schema_name as schema_name,
                     (rf.function_id).name as function_name,
                     (rf.function_id).parameters as function_parameters,
                     rf.default_args as default_args,


### PR DESCRIPTION
Missed reference in the server when calling resource functions